### PR TITLE
Throw exception if transformations is undefined

### DIFF
--- a/src/Factory/MetamorphConfigFactory.php
+++ b/src/Factory/MetamorphConfigFactory.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Metamorph\Factory;
 
+use InvalidArgumentException;
+
 class MetamorphConfigFactory
 {
     private $entityClasses;
@@ -77,7 +79,10 @@ class MetamorphConfigFactory
     private function setConfig($config)
     {
         $this->objects = array_keys($config['objects']);
-        $this->transformations = $config['config']['transformations'] ?? [];
+        if (empty($config['config']['transformations'])) {
+            throw new InvalidArgumentException('The transformations is not found');
+        }
+        $this->transformations = $config['config']['transformations'];
         $this->usages = $config['config']['usage'] ?? [];
 
         $this->configureEntities($config);

--- a/tests/_support/Fixture/TestConfigWithoutTransformations.php
+++ b/tests/_support/Fixture/TestConfigWithoutTransformations.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Fixture;
+
+class TestConfigWithoutTransformations
+{
+    public static function get()
+    {
+        return include __DIR__ . '/config/no_transformations.php';
+    }
+}

--- a/tests/_support/Fixture/config/no_transformations.php
+++ b/tests/_support/Fixture/config/no_transformations.php
@@ -1,0 +1,114 @@
+<?php
+return [
+    'metamorph' => [
+        'config'       => [
+            'entities'        => [
+                '_path'      => __DIR__.'/..',
+                '_namespace' => 'Tests\Fixture',
+            ],
+            'transformers'    => [
+                '_path'      => __DIR__.'/../Transformer',
+                '_namespace' => 'Tests\Fixture\Transformer',
+                'address'    => [
+                    '_path'      => __DIR__.'/../Transformer/User',
+                    '_namespace' => 'Tests\Fixture\Transformer\User',
+                ],
+            ],
+            'usage'           => [
+                'object' => [
+                    'array' => [
+                        'user',
+                    ],
+                ],
+                'array'  => [
+                    'object' => [
+                        'user',
+                    ],
+                ],
+            ],
+        ],
+        'objects'      => [
+            'user'    => [
+                'class'      => 'TestUser',
+                'properties' => [
+                    'address'         => [
+                        'object' => 'address',
+                    ],
+                    'allowed'         => [
+                        'scalar' => 'bool',
+                    ],
+                    'birthday'        => [
+                        'class' => 'Carbon\Carbon',
+                    ],
+                    'email'           => [
+                        'isCollection' => true,
+                        'object'       => 'email',
+                    ],
+                    'favoriteNumbers' => [
+                        'isCollection' => true,
+                        'scalar'       => 'int',
+                    ],
+                    'id'              => [
+                        'class' => 'Ramsey\Uuid',
+                    ],
+                    'username'        => [],
+                ],
+            ],
+            'address' => [
+                'class'      => 'TestAddress',
+                'properties' => [
+                    'city'  => [
+                        'scalar' => 'string',
+                    ],
+                    'state' => [
+                        'scalar' => 'string',
+                    ],
+                    'zip'   => [
+                        'scalar' => 'string',
+                    ],
+                ],
+            ],
+            'email'   => [
+                'class'      => 'TestEmail',
+                'properties' => [
+                    'label' => [
+                        'type' => 'string',
+                    ],
+                    'value' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ],
+        'transformers' => [
+            'array' => [
+                'user'    => [
+                    'class'      => null,
+                    'properties' => [
+                        'birthday' => [
+                            '_from' => ['format' => 'inclusiveDateTime'],
+                            '_to'   => ['format' => 'Iso8601'],
+                            'name'  => 'birth_day',
+                        ],
+                        'favoriteNumbers' => [
+                            'scalar'       => 'string',
+                        ],
+                        'id'       => [
+                            'name'   => '_id',
+                            'scalar' => 'string',
+                        ],
+                    ],
+                ],
+                'address' => [
+                    'class'   => null,
+                    'exclude' => [
+                        'zip',
+                    ],
+                ],
+                'email'   => [
+                    'class' => null,
+                ],
+            ],
+        ],
+    ],
+];

--- a/tests/unit/Factory/MetamorphConfigFactoryCest.php
+++ b/tests/unit/Factory/MetamorphConfigFactoryCest.php
@@ -5,8 +5,10 @@ namespace Tests\Unit\Factory;
 
 use Metamorph\Factory\MetamorphConfigFactory;
 use Tests\Fixture\TestConfig;
+use Tests\Fixture\TestConfigWithoutTransformations;
 use Tests\Fixture\TestConfigNormalized;
 use UnitTester;
+use InvalidArgumentException;
 
 class MetamorphConfigFactoryCest
 {
@@ -19,5 +21,13 @@ class MetamorphConfigFactoryCest
         $expected = TestConfigNormalized::get();
 
         $I->assertEquals($expected, $normalized);
+    }
+
+    public function testInvokeWithoutTransformationsConfig(UnitTester $I)
+    {
+        $I->expectException(new InvalidArgumentException('The transformations is not found'), function() {
+            $config = TestConfigWithoutTransformations::get();
+            (new MetamorphConfigFactory())($config);
+        });
     }
 }


### PR DESCRIPTION
As title, and it's related to issue #2.

Remove the `??` syntax and using the `empty` function to check whether the `transformations` key is defined in `$config` associate array.